### PR TITLE
Fix: data from one storage overlaps data from other storage

### DIFF
--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -45,7 +45,7 @@ export default Ember.Mixin.create({
     serialized = storage[storageKey];
 
     // Merge the serialized version into defaults.
-    content = initialContent;
+    content = Ember.copy(initialContent, true);
     if (serialized) {
       content = Ember.merge(content, JSON.parse(serialized));
     }

--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -47,7 +47,7 @@ export default Ember.Mixin.create({
     // Merge the serialized version into defaults.
     content = Ember.copy(initialContent, true);
     if (serialized) {
-      content = Ember.merge(content, JSON.parse(serialized));
+      Ember.merge(content, JSON.parse(serialized));
     }
 
     this.set('content', content);


### PR DESCRIPTION
Hi, thank you for your addon!

I'm using both localStorage and sessionStorage simultaneously with same extension object. Here is my files: 

### ./config.js
```
export default {
    storageKey: 'api-token', 
    initialContent: {
        token: null
    }
};
```

### ./session-storage.js
```
import config from './config';
import StorageObject from 'ember-local-storage/session/object';

export default StorageObject.extend(config);
```

### ./local-storage.js
```
import config from './config';
import StorageObject from 'ember-local-storage/local/object';

export default StorageObject.extend(config);
```

[Ember.merge()](http://emberjs.com/api/classes/Ember.html#method_copy) merges everything into object passed as first argument. As first argument you are passing my "config" (**singleton** in my case), and then passes merged object to ObjectProxy. So, when I create local storage and session storage objects one by one, **second overtires loaded content of the first one**.

I'm suggest to add Ember.copy function call, this will split objects from each other.

Sorry for my English.
