### PR TITLE
add reset() method. Fixes #7

### DIFF
--- a/addon/mixins/object.js
+++ b/addon/mixins/object.js
@@ -12,5 +12,11 @@ export default Ember.Mixin.create(StorageProxyMixin, {
   set: function(key, value) {
     this._super(key, value);
     this.save();
+  },
+
+  reset: function() {
+    var initialContent = this.get('initialContent');
+    var content = Ember.copy(initialContent, true);
+    this.set('content', content);
   }
 });

--- a/addon/mixins/object.js
+++ b/addon/mixins/object.js
@@ -12,11 +12,5 @@ export default Ember.Mixin.create(StorageProxyMixin, {
   set: function(key, value) {
     this._super(key, value);
     this.save();
-  },
-
-  reset: function() {
-    var initialContent = this.get('initialContent');
-    var content = Ember.copy(initialContent, true);
-    this.set('content', content);
   }
 });

--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -48,10 +48,7 @@ export default Ember.Mixin.create({
     serialized = storage[storageKey];
 
     // Merge the serialized version into defaults.
-    content = Ember.copy(initialContent, true);
-    // Ember.copy returns a normal array when prototype extensions are off
-    // This ensures that we wrap in an Ember Array.
-    content = Ember.isArray(content) ? Ember.A(content) : content;
+    content = this._getInitialContentCopy();
 
     if (serialized) {
       Ember.merge(content, JSON.parse(serialized));
@@ -74,5 +71,18 @@ export default Ember.Mixin.create({
 
   storage: function() {
     return getStorage(this.get('_storage'));
+  },
+
+  _getInitialContentCopy: function() {
+    var initialContent = this.get('initialContent');
+    var content = Ember.copy(initialContent, true);
+    // Ember.copy returns a normal array when prototype extensions are off
+    // This ensures that we wrap it in an Ember Array.
+    return Ember.isArray(content) ? Ember.A(content) : content;
+  },
+
+  reset: function() {
+    var content = this._getInitialContentCopy();
+    this.set('content', content);
   }
 });

--- a/tests/unit/array-test.js
+++ b/tests/unit/array-test.js
@@ -45,3 +45,29 @@ test('it does not share data', function(assert) {
   // ImageLikes don't change
   assert.deepEqual(imageLikes.get('content'), ['martin']);
 });
+
+test('reset method restores initialContent', function(assert) {
+  var imageLikes = AnonymousLikes.create({
+    storageKey: 'image-likes',
+  });
+
+  assert.expect(3);
+
+  //initialContent is set properly
+  assert.deepEqual(imageLikes.get('content'), []);
+
+  //add new objects
+  Ember.run(function() {
+    imageLikes.addObject('martin');
+  });
+
+  //we expect them to be present
+  assert.deepEqual(imageLikes.get('content'), ['martin']);
+
+  //reset
+  imageLikes.reset();
+
+  //data is back to initial values
+  assert.deepEqual(imageLikes.get('content'), []);
+
+});

--- a/tests/unit/object-test.js
+++ b/tests/unit/object-test.js
@@ -52,3 +52,35 @@ test('it does not share data', function(assert) {
 
   assert.deepEqual(session.get('token'), '123456');
 });
+
+test('reset method restores initialContent', function(assert) {
+  var Local = LocalStorageObject.extend(config);
+  var local = Local.create();
+
+  assert.expect(5);
+
+  //initialContent is set properly
+  assert.deepEqual(local.get('content'), {
+    token: null
+  });
+
+  //set new properties and overwrite others
+  Ember.run(function() {
+    local.set('newProp', 'some-value');
+    local.set('token', 'new-token');
+  });
+
+  //we expect them to
+  assert.equal(local.get('newProp'), 'some-value');
+  assert.equal(local.get('token'), 'new-token');
+
+  //reset
+  local.reset();
+
+  //data is back to initial values
+  assert.deepEqual(local.get('content'), {
+    token: null
+  });
+  assert.strictEqual(local.get('newProp'), undefined);
+
+});

--- a/tests/unit/object-test.js
+++ b/tests/unit/object-test.js
@@ -70,7 +70,7 @@ test('reset method restores initialContent', function(assert) {
     local.set('token', 'new-token');
   });
 
-  //we expect them to
+  //we expect them to be present
   assert.equal(local.get('newProp'), 'some-value');
   assert.equal(local.get('token'), 'new-token');
 


### PR DESCRIPTION
Reset for objects and arrays.
Please publish and add a changelog entry.

Don't know if an entry about `reset()` should be added to the readme.