### PR TITLE
Add syncing via "storage" events

### DIFF
--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -55,6 +55,15 @@ export default Mixin.create({
     // Do not change to set(this, 'content', content)
     this.set('content', content);
 
+    // Keep in sync with other windows
+    if (window.addEventListener) {
+      window.addEventListener('storage', (event) => {
+        if (event.key === storageKey) {
+          this.set('content', JSON.parse(event.newValue));
+        }
+      });
+    }
+
     return this._super.apply(this, arguments);
   },
 

--- a/tests/unit/local/settings-test.js
+++ b/tests/unit/local/settings-test.js
@@ -46,3 +46,16 @@ test('it saves changes to localStorage', function(assert) {
     welcomeMessageSeen: true
   });
 });
+
+test('it updates when change events fire', function(assert) {
+  assert.expect(3);
+
+  assert.equal(settings.get('changeFired'), undefined);
+  window.dispatchEvent(new window.StorageEvent('storage', {
+    key: 'settings',
+    newValue: '{"welcomeMessageSeen":false,"changeFired":true}',
+    oldValue: '{"welcomeMessageSeen":false}'
+  }));
+  assert.equal(settings.get('welcomeMessageSeen'), false);
+  assert.equal(settings.get('changeFired'), true);
+});


### PR DESCRIPTION
This PR adds support the `storage` event, which is fired when another
window in the same domain changes a localStorage key. This allows
copies of localStorage data to stay synced across tabs.