### PR TITLE
make queryRecord returns null instead of undefined

### DIFF
--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -106,7 +106,7 @@ export default Adapter.extend(ImportExportMixin, {
 
     return records
       .then(function(result) {
-        return {data: result.data[0]};
+        return {data: result.data[0] === undefined ? null : result.data[0]};
       });
   },
 

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -153,3 +153,22 @@ test('queryRecord attributes', function(assert) {
       done();
     });
 });
+
+test('queryRecord empty store', function(assert) {
+  assert.expect(2);
+  const done = assert.async();
+  const store = this.store();
+  let posts = store.findAll('post');
+
+  assert.equal(get(posts, 'length'), 0);
+
+  store.queryRecord('post', { filter: { name: 'Super Name' } })
+    .then(function(post) {
+      assert.strictEqual(post, undefined);
+      done();
+    }).catch(function(error) {
+    assert.ok(false, 'queryRecord on empty store throws error: ' + error.message);
+    done();
+  });
+});
+


### PR DESCRIPTION
Ember expects this and asserts otherwise (see
ember-data/lib/system/store/serializer-response.js#L78)

fixes #44