### PR TITLE
Filter out null records from adapter

### DIFF
--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -157,6 +157,9 @@ export default Adapter.extend(ImportExportMixin, {
     }
 
     const records = this._getIndex(type)
+      .filter(function(storageKey) {
+        return storage[storageKey];
+      })
       .map(function(storageKey) {
         return JSON.parse(storage[storageKey]);
       });


### PR DESCRIPTION
Hey there, first of all thanks for the addon!

I was trying to use it in one of our projects and I realized that when a user clears the local storage, the adapter will still try to access the records through the `_indices` property, so `JSON.parse` will fail because it will try to parse `undefined`.

Let me know if this looks good :)