### PR TITLE
Fix getOwner() usage

### DIFF
--- a/addon/helpers/storage.js
+++ b/addon/helpers/storage.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   assert,
   computed,
+  getOwner,
   String: {
     dasherize
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-babel": "^5.2.1",
     "ember-cli-version-checker": "^1.1.7",
     "ember-cli-string-utils": "^1.0.0",
-    "ember-getowner-polyfill": "^1.0.1"
+    "ember-getowner-polyfill": "^1.1.1"
   },
   "keywords": [
     "ember-addon",

--- a/tests/unit/adapters/import-export-test.js
+++ b/tests/unit/adapters/import-export-test.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import { moduleForModel, test } from 'ember-qunit';
 import testData from '../../helpers/test-data';
 import { initialize } from 'ember-local-storage/initializers/local-storage-adapter';
 
 const {
   get,
+  getOwner,
   run
 } = Ember;
 

--- a/tests/unit/adapters/indices-test.js
+++ b/tests/unit/adapters/indices-test.js
@@ -1,9 +1,11 @@
-import getOwner from 'ember-getowner-polyfill';
+import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 import {
   storageEqual,
   storageDeepEqual
 } from '../../helpers/storage';
+
+const { getOwner } = Ember;
 
 moduleFor('adapter:application', 'Unit | Adapter | indices', {
   // Specify the other units that are required for this test.

--- a/tests/unit/array-test.js
+++ b/tests/unit/array-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { moduleFor, test } from 'ember-qunit';
 import {
   storageDeepEqual
 } from '../helpers/storage';
@@ -10,33 +10,25 @@ import {
   _resetStorages
 } from 'ember-local-storage/helpers/storage';
 
-let registry;
-let container;
 let subject;
-
-const registryOpts = { singleton: true, instantiate: false };
 
 const {
   run,
   get
 } = Ember;
 
-module('array - likes', {
+moduleFor('router:main', 'array - likes', {
   beforeEach() {
-    registry  = new Ember.Registry();
-    container = new Ember.Container(registry);
-
     let mockStorage = StorageArray.extend();
     let mockStorageB = StorageArray.extend();
 
-    registry.register('storage:anonymous-likes', mockStorage, registryOpts);
-    registry.register('storage:post-likes', mockStorageB, registryOpts);
-
-    subject = Ember.Object.extend({
-      container,
+    this.register('storage:anonymous-likes', mockStorage);
+    this.register('storage:post-likes', mockStorageB);
+    this.register('object:test', Ember.Object.extend({
       anonymousLikes: storageFor('anonymous-likes'),
       postLikes: storageFor('post-likes')
-    }).create();
+    }));
+    subject = this.container.lookup('object:test');
   },
   afterEach() {
     window.localStorage.clear();

--- a/tests/unit/legacy-test.js
+++ b/tests/unit/legacy-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { moduleFor, test } from 'ember-qunit';
 import {
   storageDeepEqual
 } from '../helpers/storage';
@@ -10,17 +10,10 @@ import {
   _resetStorages
 } from 'ember-local-storage/helpers/storage';
 
-let registry;
-let container;
 let subject;
 
-const registryOpts = { singleton: true, instantiate: false };
-
-module('legacy - config', {
+moduleFor('router:main', 'legacy - config', {
   beforeEach() {
-    registry  = new Ember.Registry();
-    container = new Ember.Container(registry);
-
     // old serialized content
     window.localStorage.settings = JSON.stringify({
       mapStyle: 'dark'
@@ -36,12 +29,11 @@ module('legacy - config', {
       }
     });
 
-    registry.register('storage:config', mockStorage, registryOpts);
-
-    subject = Ember.Object.extend({
-      container,
+    this.register('storage:config', mockStorage);
+    this.register('object:test', Ember.Object.extend({
       settings: storageFor('config', { legacyKey: 'settings' })
-    }).create();
+    }));
+    subject = this.container.lookup('object:test');
   },
   afterEach() {
     window.localStorage.clear();

--- a/tests/unit/models/blog/post-test.js
+++ b/tests/unit/models/blog/post-test.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
+  getOwner,
   run
 } = Ember;
 

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
+  getOwner,
   run
 } = Ember;
 

--- a/tests/unit/models/query-record-test.js
+++ b/tests/unit/models/query-record-test.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
+  getOwner,
   run
 } = Ember;
 

--- a/tests/unit/models/query-test.js
+++ b/tests/unit/models/query-test.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
+  getOwner,
   run
 } = Ember;
 

--- a/tests/unit/object-test.js
+++ b/tests/unit/object-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { moduleFor, test } from 'ember-qunit';
 import {
   storageDeepEqual
 } from '../helpers/storage';
@@ -11,22 +11,15 @@ import {
   _resetStorages
 } from 'ember-local-storage/helpers/storage';
 
-let registry;
-let container;
 let subject;
-
-const registryOpts = { singleton: true, instantiate: false };
 
 const {
   run,
   get
 } = Ember;
 
-module('object - settings', {
+moduleFor('router:main', 'object - settings', {
   beforeEach() {
-    registry  = new Ember.Registry();
-    container = new Ember.Container(registry);
-
     let mockStorage = StorageObject.extend();
     let mockStorageB = StorageObject.extend();
     let mockStorageC = SessionStorageObject.extend();
@@ -52,18 +45,18 @@ module('object - settings', {
       }
     });
 
-    registry.register('storage:settings', mockStorage, registryOpts);
-    registry.register('storage:nested-objects', mockStorageB, registryOpts);
-    registry.register('storage:cache', mockStorageC, registryOpts);
-    registry.register('storage:local-cache', mockStorageD, registryOpts);
+    this.register('storage:settings', mockStorage);
+    this.register('storage:nested-objects', mockStorageB);
+    this.register('storage:cache', mockStorageC);
+    this.register('storage:local-cache', mockStorageD);
 
-    subject = Ember.Object.extend({
-      container,
+    this.register('object:test', Ember.Object.extend({
       settings: storageFor('settings'),
       nestedObjects: storageFor('nested-objects'),
       cache: storageFor('cache'),
       localCache: storageFor('local-cache')
-    }).create();
+    }));
+    subject = this.container.lookup('object:test');
   },
   afterEach() {
     window.localStorage.clear();

--- a/tests/unit/storage-for-test.js
+++ b/tests/unit/storage-for-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { moduleFor, test } from 'ember-qunit';
 import {
   storageDeepEqual
 } from '../helpers/storage';
@@ -10,16 +10,8 @@ import {
   _resetStorages
 } from 'ember-local-storage/helpers/storage';
 
-let registry;
-let container;
-
-const registryOpts = { singleton: true, instantiate: false };
-
-module('legacy - config', {
+moduleFor('router:main', 'legacy - config', {
   beforeEach() {
-    registry  = new Ember.Registry();
-    container = new Ember.Container(registry);
-
     let mockStorage = StorageObject.extend();
 
     mockStorage.reopenClass({
@@ -30,7 +22,7 @@ module('legacy - config', {
       }
     });
 
-    registry.register('storage:settings', mockStorage, registryOpts);
+    this.register('storage:settings', mockStorage);
   },
   afterEach() {
     window.localStorage.clear();
@@ -46,11 +38,11 @@ test('it has the correct key', function(assert) {
     id: '123'
   }).create();
 
-  let subject = Ember.Object.extend({
-    container,
+  this.register('object:test', Ember.Object.extend({
     post: post,
     settings: storageFor('settings', 'post')
-  }).create();
+  }));
+  let subject = this.container.lookup('object:test');
 
   assert.equal(
     subject.get('settings._storageKey'),


### PR DESCRIPTION
Use Ember.getOwner() instead of the importing directly from the polyfill. This broke some of the unit tests that were doing custom container/registry setup, so I ported them to moduleFor() to take advantage of the standard isolated container code, and then look up the subject from the container so getOwner() works without any hackery.