### PR TITLE
Don't leak _indices into registry

### DIFF
--- a/addon/adapters/base.js
+++ b/addon/adapters/base.js
@@ -14,7 +14,8 @@ const {
   run,
   Inflector,
   typeOf,
-  isEmpty
+  isEmpty,
+  computed
 } = Ember;
 
 // Ember data ships with ember-inflector
@@ -22,7 +23,7 @@ const inflector = Inflector.inflector;
 
 export default JSONAPIAdapter.extend(ImportExportMixin, {
   _debug: false,
-  _indices: {},
+  _indices: computed(function() { return {}; }),
   isNewSerializerAPI: true,
   coalesceFindRequests: false,
 


### PR DESCRIPTION
The _indices property was being shared across all instances of adapters. Generally this shouldn't be a problem, but in tests that set up and tear down different isolation containers, it would cause state to leak between tests. It is specifically problematic if a test manually pushes records into localStorage or sessionStorage during test setup, before the adapter has been instantiated, because then the adapter instance inherits the _indices from the previous test's adapter instance, but doesn't receive notifications to update it during the second test's setup. So, _indices gets out of sync with the underlying storage. This way each new adapter instance initializes its _indices from the underlying storage and there is no chance of state leakage/corruption.

This is currently failing because of the getOwner() polyfill issue, so once that has been fixed I can rebase this and the tests will pass.