### PR TITLE
tryStorage returns undefined when no storage is available

### DIFF
--- a/addon/helpers/storage.js
+++ b/addon/helpers/storage.js
@@ -22,7 +22,7 @@ function tryStorage(name) {
     nativeStorage.setItem('emberlocalstorage.test', 'ok');
     nativeStorage.removeItem('emberlocalstorage.test');
   } catch (e) {
-    nativeStorage = null;
+    nativeStorage = undefined;
   }
 
   return nativeStorage;


### PR DESCRIPTION
Returning `undefined` in `tryStorage` makes it more consistent to use `getWithDefault` in the rare occasions when no storage is available, _eg_ in Private mode in Safari.

FWIW, the PR could have just been the removal of the line, but assigning explicitly to `undefined` gives a bit more clarity to the code, IMHO.
