### PR TITLE
Handle not found errors

### DIFF
--- a/addon/adapters/base.js
+++ b/addon/adapters/base.js
@@ -166,7 +166,10 @@ export default JSONAPIAdapter.extend(ImportExportMixin, {
       storageKey = this._storageKey(type, id);
 
     if (id) {
-      return storage[storageKey] ? JSON.parse(storage[storageKey]) : null;
+      if (!storage[storageKey]) {
+        throw this.handleResponse(404, {}, "Not found", { url, method: 'GET' });
+      }
+      return JSON.parse(storage[storageKey]);
     }
 
     const records = this._getIndex(type)

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -1,8 +1,26 @@
+import Ember from 'ember';
+import DS from 'ember-data';
 import { moduleFor, test } from 'ember-qunit';
 
+const { run } = Ember;
+
+const {
+  AdapterError,
+  Model,
+  attr
+} = DS;
+
+let SimpleModel = Model.extend({
+  prop: attr('string')
+});
+
 moduleFor('adapter:application', 'Unit | Adapter | application', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: [ 'serializer:application' ],
+
+  beforeEach() {
+    this.register('model:simple', SimpleModel);
+    this.store = this.container.lookup('service:store');
+  }
 });
 
 // Replace this with your real tests.
@@ -19,4 +37,16 @@ test('it has a importData method', function(assert) {
 test('it has a exportData method', function(assert) {
   var adapter = this.subject();
   assert.ok(typeof adapter.exportData === 'function');
+});
+
+test('it handles requests for missing records', function(assert) {
+  assert.expect(1);
+
+  return run(() => {
+    return this.store.findRecord('simple', '12345').then(() => {
+      assert.notOk(true, "should not have succeeded");
+    }).catch((e) => {
+      assert.ok(e instanceof AdapterError, "an adapter error was thrown");
+    });
+  });
 });


### PR DESCRIPTION
If the record being requested isn't present, return a not found error. The previous behavior was to return a successful response from ajax(), but with an empty payload, which would cause the store to throw an exception. This way an exception is still thrown, but it's an AdapterError, so should fit better with application logic handling such errors.