### PR TITLE
Fix importData

### DIFF
--- a/addon/helpers/import-export.js
+++ b/addon/helpers/import-export.js
@@ -1,0 +1,98 @@
+import Ember from 'ember';
+
+const {
+  get,
+  String: {
+    singularize
+  },
+  run
+} = Ember;
+
+const assign = Ember.assign || Ember.merge;
+
+export function importData(store, content, options) {
+  // merge defaults
+  options = assign({
+    json: true,
+    truncate: true
+  }, options || {});
+
+  let reloadTypes = [];
+
+  content = options.json ? JSON.parse(content) : content;
+
+  if (options.truncate) {
+    content.data.forEach((record) => {
+      const type = record.type;
+      const adapter = store.adapterFor(singularize(type));
+
+      adapter._getIndex(type).forEach((storageKey) => {
+        delete get(adapter, '_storage')[storageKey];
+      });
+
+      adapter._getIndex(type).reset();
+
+      // unload from store
+      store.unloadAll(singularize(type));
+    });
+  }
+
+  const promises = content.data.map((record) => {
+    const adapter = store.adapterFor(singularize(record.type));
+
+    // collect types to reload
+    reloadTypes.push(singularize(record.type));
+
+    return adapter._handleStorageRequest(null, 'POST', {
+      data: {data: record}
+    });
+  });
+
+  return Ember.RSVP.all(promises)
+    .then(function() {
+      // reload from store
+      reloadTypes.forEach(function(type) {
+        store.findAll(type);
+      });
+    });
+}
+
+export function exportData(store, types, options) {
+  // merge defaults
+  options = assign({
+    json: true,
+    download: false,
+    filename: 'ember-data.json'
+  }, options || {});
+
+  let json, data;
+
+  // collect data
+  data = types.reduce((records, type) => {
+    const adapter = store.adapterFor(singularize(type));
+    const url = adapter.buildURL(type),
+      exportData = adapter._handleGETRequest(url);
+
+    records.data = records.data.concat(exportData);
+    return records;
+  }, {data: []});
+
+  if (options.json || options.download) {
+    json = JSON.stringify(data);
+  }
+
+  if (options.json) {
+    data = json;
+  }
+
+  if (options.download) {
+    window.saveAs(
+      new Blob([json], {type: 'application/json;charset=utf-8'}),
+      options.filename
+    );
+  }
+
+  return new Ember.RSVP.Promise((resolve) => {
+    run(null, resolve, data);
+  }, 'DS: LocalStorageAdapter#exportData');
+}

--- a/addon/initializers/local-storage-adapter.js
+++ b/addon/initializers/local-storage-adapter.js
@@ -1,17 +1,15 @@
 import DS from 'ember-data';
-import Adapter from 'ember-local-storage/adapters/adapter';
+import { importData, exportData } from 'ember-local-storage/helpers/import-export';
 
 export function initialize() {
   if (!DS.Store.prototype._emberLocalStoragePatched) {
-    const adapter = Adapter.create();
-
     DS.Store.reopen({
       _emberLocalStoragePatched: true,
       importData: function(json, options) {
-        return adapter.importData.call(adapter, this, json, options);
+        return importData(this, json, options);
       },
       exportData: function(types, options) {
-        return adapter.exportData.call(adapter, this, types, options);
+        return exportData(this, types, options);
       }
     });
   }

--- a/addon/mixins/adapters/import-export.js
+++ b/addon/mixins/adapters/import-export.js
@@ -1,97 +1,16 @@
 import Ember from 'ember';
+import { importData, exportData } from 'ember-local-storage/helpers/import-export';
 
 const {
   Mixin,
-  get,
-  String: {
-    singularize
-  },
-  run
 } = Ember;
-
-const assign = Ember.assign || Ember.merge;
 
 export default Mixin.create({
   importData(store, content, options) {
-    // merge defaults
-    options = assign({
-      json: true,
-      truncate: true
-    }, options || {});
-
-    let reloadTypes = [];
-
-    content = options.json ? JSON.parse(content) : content;
-
-    if (options.truncate) {
-      content.data.forEach((record) => {
-        const type = record.type;
-
-        this._getIndex(type).forEach((storageKey) => {
-          delete get(this, '_storage')[storageKey];
-        });
-
-        this._getIndex(type).reset();
-
-        // unload from store
-        store.unloadAll(singularize(type));
-      });
-    }
-
-    const promises = content.data.map((record) => {
-      // collect types to reload
-      reloadTypes.push(singularize(record.type));
-
-      return this._handleStorageRequest(null, 'POST', {
-        data: {data: record}
-      });
-    });
-
-    return Ember.RSVP.all(promises)
-      .then(function() {
-        // reload from store
-        reloadTypes.forEach(function(type) {
-          store.findAll(type);
-        });
-      });
+    return importData(store, content, options);
   },
 
   exportData(store, types, options) {
-    // merge defaults
-    options = assign({
-      json: true,
-      download: false,
-      filename: 'ember-data.json'
-    }, options || {});
-
-    let json, data;
-
-    // collect data
-    data = types.reduce((records, type) => {
-      const url = this.buildURL(type),
-        exportData = this._handleGETRequest(url);
-
-      records.data = records.data.concat(exportData);
-      return records;
-    }, {data: []});
-
-    if (options.json || options.download) {
-      json = JSON.stringify(data);
-    }
-
-    if (options.json) {
-      data = json;
-    }
-
-    if (options.download) {
-      window.saveAs(
-        new Blob([json], {type: 'application/json;charset=utf-8'}),
-        options.filename
-      );
-    }
-
-    return new Ember.RSVP.Promise((resolve) => {
-      run(null, resolve, data);
-    }, 'DS: LocalStorageAdapter#exportData');
+    return exportData(store, types, options);
   }
 });

--- a/tests/unit/adapters/import-export-test.js
+++ b/tests/unit/adapters/import-export-test.js
@@ -2,10 +2,10 @@ import Ember from 'ember';
 import { moduleForModel, test } from 'ember-qunit';
 import testData from '../../helpers/test-data';
 import { initialize } from 'ember-local-storage/initializers/local-storage-adapter';
+import SessionStorageAdapter from 'ember-local-storage/adapters/session';
 
 const {
   get,
-  getOwner,
   run
 } = Ember;
 
@@ -18,65 +18,122 @@ moduleForModel('post', 'Unit | Adapter | import/export', {
   ],
   beforeEach: function() {
     initialize();
-    const adapter = getOwner(this).lookup('adapter:application');
-    adapter._getIndex('posts').reset();
-    adapter._getIndex('comments').reset();
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 
 test('import', function(assert) {
   assert.expect(2);
-  const done = assert.async();
   const store = this.store();
 
-  run(function() {
-    store.importData(testData.importFileContent)
-      .then(function() {
-        const posts = store.findAll('post');
-        const comments = store.findAll('comment');
+  return run(function() {
+    return store.importData(testData.importFileContent);
+  }).then(function() {
+    const posts = store.findAll('post');
+    const comments = store.findAll('comment');
 
-        Ember.RSVP
-          .hash({
-            posts: posts,
-            comments: comments
-          })
-          .then(function(data) {
-            assert.equal(get(data.posts, 'length'), 2);
-            assert.equal(get(data.comments, 'length'), 3);
-            done();
-          });
-      });
+    return Ember.RSVP.hash({
+      posts: posts,
+      comments: comments
+    });
+  }).then(function(data) {
+    assert.equal(get(data.posts, 'length'), 2);
+    assert.equal(get(data.comments, 'length'), 3);
   });
 });
 
-test('import', function(assert) {
-  assert.expect(1);
-  const done = assert.async();
+test('import with records loaded', function(assert) {
+  assert.expect(2);
   const store = this.store();
 
-  run(function() {
-    store.importData(testData.importFileContent)
-      .then(function() {
-        const posts = store.findAll('post');
-        const comments = store.findAll('comment');
+  return run(function() {
+    return Ember.RSVP.hash({
+      posts: store.findAll('post'),
+      comments:  store.findAll('comment')
+    });
+  }).then(function() {
+    return store.importData(testData.importFileContent);
+  }).then(function() {
+    return Ember.RSVP.hash({
+      posts: store.findAll('post'),
+      comments:  store.findAll('comment')
+    });
+  }).then(function(data) {
+    assert.equal(get(data.posts, 'length'), 2);
+    assert.equal(get(data.comments, 'length'), 3);
+  });
+});
 
-        Ember.RSVP
-          .hash({
-            posts: posts,
-            comments: comments
-          })
-          .then(function() {
-            store.exportData(
-              ['posts', 'comments'],
-              {json: false}
-            )
-            .then(function(data) {
-              assert.equal(data.data.length, 5);
-              done();
-            });
-          });
-      });
+test('import to multiple adapter types', function(assert) {
+  assert.expect(4);
+  this.register('adapter:post', SessionStorageAdapter);
+
+  const store = this.store();
+
+  return run(function() {
+    return store.importData(testData.importFileContent);
+  }).then(function() {
+    const posts = store.findAll('post');
+    const comments = store.findAll('comment');
+
+    return Ember.RSVP.hash({
+      posts: posts,
+      comments: comments
+    });
+  }).then(function(data) {
+    assert.equal(get(data.posts, 'length'), 2);
+    assert.equal(get(data.comments, 'length'), 3);
+    assert.equal(JSON.parse(window.localStorage['index-comments']).length, 3);
+    assert.equal(JSON.parse(window.sessionStorage['index-posts']).length, 2);
+  });
+});
+
+test('export', function(assert) {
+  assert.expect(1);
+  const store = this.store();
+
+  return run(function() {
+    return store.importData(testData.importFileContent);
+  }).then(function() {
+    const posts = store.findAll('post');
+    const comments = store.findAll('comment');
+
+    return Ember.RSVP.hash({
+      posts: posts,
+      comments: comments
+    });
+  }).then(function() {
+    return store.exportData(
+      ['posts', 'comments'],
+      {json: false}
+    );
+  }).then(function(data) {
+    assert.equal(data.data.length, 5);
+  });
+});
+
+test('export from multiple adapter types', function(assert) {
+  assert.expect(1);
+  const store = this.store();
+  this.register('adapter:post', SessionStorageAdapter);
+
+  return run(function() {
+    return store.importData(testData.importFileContent);
+  }).then(function() {
+    const posts = store.findAll('post');
+    const comments = store.findAll('comment');
+
+    return Ember.RSVP.hash({
+      posts: posts,
+      comments: comments
+    });
+  }).then(function() {
+    return store.exportData(
+      ['posts', 'comments'],
+      {json: false}
+    );
+  }).then(function(data) {
+    assert.equal(data.data.length, 5);
   });
 });

--- a/tests/unit/adapters/indices-test.js
+++ b/tests/unit/adapters/indices-test.js
@@ -1,25 +1,15 @@
-import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 import {
   storageEqual,
   storageDeepEqual
 } from '../../helpers/storage';
 
-const {
-  getOwner
-} = Ember;
-
 moduleFor('adapter:application', 'Unit | Adapter | indices', {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
   beforeEach: function() {
-    const adapter = getOwner(this).lookup('adapter:application');
-
-    ['projects'].forEach(function(key) {
-      adapter._getIndex(key).reset();
-    });
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 

--- a/tests/unit/models/blog/post-test.js
+++ b/tests/unit/models/blog/post-test.js
@@ -3,7 +3,6 @@ import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
-  getOwner,
   run
 } = Ember;
 
@@ -16,13 +15,8 @@ moduleForModel('blog/post', 'Unit | Model | blog/post', {
     'model:user',
   ],
   beforeEach: function() {
-    const adapter = getOwner(this).lookup('adapter:blog/post');
-
-    ['blog/posts'].forEach(function(key) {
-      adapter._getIndex(key).reset();
-    });
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -4,7 +4,6 @@ import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
-  getOwner,
   run
 } = Ember;
 
@@ -20,13 +19,8 @@ moduleForModel('post', 'Unit | Model | post', {
     'model:book-publication'
   ],
   beforeEach: function() {
-    const adapter = getOwner(this).lookup('adapter:application');
-
-    ['posts', 'users', 'projects', 'comments', 'pets'].forEach(function(key) {
-      adapter._getIndex(key).reset();
-    });
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 

--- a/tests/unit/models/query-record-test.js
+++ b/tests/unit/models/query-record-test.js
@@ -3,7 +3,6 @@ import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
-  getOwner,
   run
 } = Ember;
 
@@ -23,13 +22,8 @@ moduleForModel('post', 'Unit | Model | queryRecord', {
     'model:task'
   ],
   beforeEach: function() {
-    const adapter = getOwner(this).lookup('adapter:application');
-
-    ['posts', 'users', 'projects', 'comments', 'pets'].forEach(function(key) {
-      adapter._getIndex(key).reset();
-    });
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 

--- a/tests/unit/models/query-test.js
+++ b/tests/unit/models/query-test.js
@@ -3,7 +3,6 @@ import { moduleForModel, test } from 'ember-qunit';
 
 const {
   get,
-  getOwner,
   run
 } = Ember;
 
@@ -23,13 +22,8 @@ moduleForModel('post', 'Unit | Model | query', {
     'model:task'
   ],
   beforeEach: function() {
-    const adapter = getOwner(this).lookup('adapter:application');
-
-    ['posts', 'users', 'projects', 'comments', 'pets'].forEach(function(key) {
-      adapter._getIndex(key).reset();
-    });
-
     window.localStorage.clear();
+    window.sessionStorage.clear();
   }
 });
 


### PR DESCRIPTION
PR #219 broke importData because importData was relying on the global-ness of the adapter index.

The fix is to remove an assumption that the import/export code was making that, while probably most of the time true, is incorrect. That assumption is that a single adapter instance is responsible for all model types, and that the adapter instance is a local storage adapter. If an application was using the session storage adapter, or was using the local storage adapter for some models and the session storage adapter for others, the import and export code would do the extremely wrong thing.

So, rather than make importData/exportData fundamentally functions of the adapter, they are now fundamentally functions of the store (via helper methods), and the store looks up the correct adapter for each model type in the data payload, ensuring that it gets/sends the data from/to the right place.

I left the importData/exportData methods on the adapters (via the mixin) to preserve backwards compatibility, in case anybody was accessing the functionality through the adapter instead of the store, but it just forwards to the same helpers as the store's importData/exportData.

Also, make sure unit tests are clearing session storage as well as local storage in case we write more session storage tests, and remove code that #219 made no-longer relevant (clearing out the adapter index before each test).

Fixes #233