### PR TITLE
Moving blob-polyfill dependency from bower to npm

### DIFF
--- a/blueprints/ember-local-storage/index.js
+++ b/blueprints/ember-local-storage/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = {
-  normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('blob-polyfill');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ember-local-storage",
   "dependencies": {
-    "blob-polyfill": "~1.0.20150320",
     "highlightjs": "~9.1.0",
     "inuitcss": "^6.0.0-beta.4"
   }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@
 
 var stew = require('broccoli-stew');
 var VersionChecker = require('ember-cli-version-checker');
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-local-storage',
@@ -40,7 +43,7 @@ module.exports = {
 
       if (options.fileExport && this.hasEmberData) {
         app.import('vendor/save-as.js');
-        app.import(app.bowerDirectory + '/blob-polyfill/Blob.js');
+        app.import('vendor/Blob.js');
       }
     }
 
@@ -75,5 +78,13 @@ module.exports = {
     }
 
     return this._super.treeForAddon.call(this, tree);
+  },
+
+  treeForVendor(vendorTree) {
+    var blobTree = new Funnel(path.dirname(require.resolve('blob-polyfill')), {
+      files: ['Blob.js']
+    });
+
+    return mergeTrees([vendorTree, blobTree]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "blob-polyfill": "~1.0.20150320",
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^1.2.4",
     "broccoli-stew": "^1.4.2",
     "ember-cli-babel": "^6.1.0",
     "ember-cli-string-utils": "^1.1.0",
@@ -37,7 +40,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "^2.13.2",
+    "ember-cli": "2.13.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-dependency-checker": "^1.4.0",
     "ember-cli-eslint": "^3.1.0",


### PR DESCRIPTION
With ember-cli moving away from bower, I thought it would be nice to manage this addon's dependencies to npm so that an installation blueprint would no longer be needed.