### PR TITLE
fix chrome infinite storage loop bug

### DIFF
--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -66,6 +66,7 @@ export default Mixin.create({
 
     if (window.addEventListener) {
       this._storageEventHandler = (event) => {
+        event = this._lastStorageEvent || event;
         if (this.isDestroying) { return; }
 
         if (event.storageArea === storage && event.key === storageKey) {
@@ -86,7 +87,12 @@ export default Mixin.create({
         }
       };
 
-      window.addEventListener('storage', this._storageEventHandler, false);
+      this._debouncedStorageEventHandler = (event) => {
+        this._lastStorageEvent = event;
+        Ember.run.debounce(this, this._storageEventHandler, 0);
+      };
+
+      window.addEventListener('storage', this._debouncedStorageEventHandler, false);
     }
   },
 
@@ -110,7 +116,7 @@ export default Mixin.create({
 
   willDestroy() {
     if (this._storageEventHandler) {
-      window.removeEventHandler('storage', this._storageEventHandler, false);
+      window.removeEventListener('storage', this._storageEventHandler, false);
     }
 
     this._super(...arguments);

--- a/tests/unit/object-test.js
+++ b/tests/unit/object-test.js
@@ -138,10 +138,11 @@ test('it does not share data', function(assert) {
 });
 
 test('it updates when change events fire', function(assert) {
+  const done = assert.async();
   assert.expect(3);
 
   // setup testing
-  get(subject, 'settings')._testing = true;
+  get(subject, 'settings').set('_testing', true);// = true;
 
   assert.equal(get(subject, 'settings.changeFired'), undefined);
   window.dispatchEvent(new window.StorageEvent('storage', {
@@ -150,8 +151,12 @@ test('it updates when change events fire', function(assert) {
     oldValue: '{"welcomeMessageSeen":false}',
     storageArea: get(subject, 'settings')._storage()
   }));
-  assert.equal(get(subject, 'settings.welcomeMessageSeen'), false);
-  assert.equal(get(subject, 'settings.changeFired'), true);
+
+  Ember.run.later(() => {
+    assert.equal(get(subject, 'settings.welcomeMessageSeen'), false);
+    assert.equal(get(subject, 'settings.changeFired'), true);   
+    done(); 
+  }, 200);
 });
 
 test('nested values get persisted', function(assert) {


### PR DESCRIPTION
If you have multiple tabs open in Chrome and run the following in each tab

```
window.addEventListener('storage', (e) => {
  if(e.oldValue !== e.newValue) { window.localStorage['hi'] = e.newValue; }
})
```
and run 

```
for (var i = 0; i < 2; i++) { window.localStorage['hi'] = i.toString()}
```

, it can get into an seemingly infinite loop after having it in a certain number of tabs. Its seems to be similar to #47.