### PR TITLE
Fix ember-copy package URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/addon/serializers/serializer.js
+++ b/addon/serializers/serializer.js
@@ -4,6 +4,8 @@ const {
   JSONAPISerializer
 } = DS;
 
+const emberDataVersionOlderThan3Point1 = DS.VERSION.match(/^[0-2]\.|3\.0/);
+
 export default JSONAPISerializer.extend({
   // Serialization behavior
   // Can be removed (_shouldSerializeHasMany) removed in ember data 3.0.0
@@ -12,18 +14,18 @@ export default JSONAPISerializer.extend({
   shouldSerializeHasMany: function() { return true; },
 
   serializeBelongsTo(snapshot, json, relationship) {
-    if (DS.VERSION.match(/^3\.[1-5]\./)) {
-      this._fixSerializeBelongsTo(snapshot, json, relationship);
-    } else {
+    if (emberDataVersionOlderThan3Point1) {
       this._super.apply(this, arguments);
+    } else {
+      this._fixSerializeBelongsTo(snapshot, json, relationship);
     }
   },
 
   serializeHasMany(snapshot, json, relationship) {
-    if (DS.VERSION.match(/^3\.[1-5]\./)) {
-      this._fixSerializeHasMany(snapshot, json, relationship);
-    } else {
+    if (emberDataVersionOlderThan3Point1) {
       this._super.apply(this, arguments);
+    } else {
+      this._fixSerializeHasMany(snapshot, json, relationship);
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,7 +2564,7 @@ ember-cli@~2.18.2:
 
 ember-copy@^1.0.0:
   version "1.0.0"
-  resolved "https://artifactory.global.standardchartered.com/artifactory/api/npm/npm-release/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
+  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
   dependencies:
     ember-cli-babel "^6.6.0"
 


### PR DESCRIPTION
For whatever reason PR #287 used a non-standard (i.e. non-yarn) package URL, which seems to be defunct now.