### PR TITLE
Add syncWindows option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,22 @@ See the [CHANGELOG](CHANGELOG.md)
 
 ### Configuration
 
+Global configuration can be set in your app's `config/environment.js`. E.g.
+
+```js
+// config/environment.js
+module.exports = function() {
+  var ENV = {
+    'ember-local-storage': {
+      // Config options belong here
+    }
+  }
+};
+```
+
 #### Namespace & keyDelimiter
 
-In you apps `config/environment.js` you can set a `namespace` and a `keyDelimiter`. For backward compatibility this is a opt-in feature.
+You can set `namespace` and `keyDelimiter` options. For backward compatibility this is a opt-in feature.
 
 **Important:** Don't turn this feature on for existing apps. You will lose access to existing keys.
 
@@ -95,6 +108,10 @@ NOTE: However, there are environments where the detection fails and the support 
     }
   },
 ```
+
+#### Window Sync
+
+You can set the `syncWindows` option to `false` to disable immediate syncing across windows or tabs. The default is `true`.
 
 ### Object & Array
 

--- a/addon/helpers/storage.js
+++ b/addon/helpers/storage.js
@@ -113,7 +113,8 @@ function createStorage(context, key, modelKey, options) {
 
   const initialState = {},
     defaultState = {
-      _storageKey: storageKey
+      _storageKey: storageKey,
+      _syncWindows: _addonConfig(context).syncWindows !== false
     },
     StorageFactory = owner.lookup(storageFactory);
 
@@ -148,13 +149,14 @@ function _modelKey(model) {
 }
 
 // TODO: v2.0 - Make modulePrefix the default
-function _getNamespace(appConfig, addonConfig) {
+function _getNamespace(context) {
   // For backward compatibility this is a opt-in feature
-  let namespace = addonConfig.namespace;
+  let namespace = _addonConfig(context).namespace;
 
   // Shortcut for modulePrefix
   if (namespace === true) {
-    namespace = appConfig.modulePrefix
+    let appConfig = getOwner(context).resolveRegistration('config:environment');
+    namespace = appConfig.modulePrefix;
   }
 
   return namespace;
@@ -162,12 +164,17 @@ function _getNamespace(appConfig, addonConfig) {
 
 // TODO: Add migration helper
 function _buildKey(context, key) {
-  let appConfig = getOwner(context).resolveRegistration('config:environment');
-  let addonConfig = appConfig && appConfig['ember-local-storage'] || {};
-  let namespace = _getNamespace(appConfig, addonConfig);
+  let namespace = _getNamespace(context);
   let delimiter = addonConfig.keyDelimiter || ':';
 
   return namespace ? `${namespace}${delimiter}${key}` : key;
+}
+
+function _addonConfig(context) {
+  let appConfig = getOwner(context).resolveRegistration('config:environment');
+  let addonConfig = appConfig && appConfig['ember-local-storage'] || {};
+
+  return addonConfig;
 }
 
 // Testing helper

--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -28,6 +28,7 @@ export default Mixin.create({
     const storage = this._storage();
     const storageKey = get(this, '_storageKey');
     const initialContent = get(this, '_initialContent');
+    const syncWindows = get(this, '_syncWindows')
 
     let serialized, content;
 
@@ -46,7 +47,9 @@ export default Mixin.create({
     this.set('content', content);
 
     // Keep in sync with other windows
-    this._addStorageListener();
+    if (syncWindows) {
+      this._addStorageListener();
+    }
 
     return this._super.apply(this, arguments);
   },


### PR DESCRIPTION
Adds an `enableWindowSync` option so that changes to values in local storage can optionally not immediately propagate to other windows/tabs.

Addresses #298.

I've kept the diff small initially. A few discussion points:

- Is `enableWindowSync` the best name for this?
- Now that the global config has another option, the config section in README.md could be revised a bit to better match other addons. I can do this if desired.
- Currently this is a global option, not a per-storage option. I think this is fine initially.
- Is the way that the config value is being extracted and passed to the storage object reasonable? There's a bit of duplication in `_isWindowSyncEnabled()`. We could have a more formal 'config defaults' object and merge it with what the user provides instead. I can do this if desired.

Thanks.