### PR TITLE
Add includeEmberDataSupport config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ module.exports = function() {
 };
 ```
 
+#### Force ember-data support
+
+This addon autodetects if you use ember-data and will include the support for ember-data adapters and serializes by default. However, in some cases the detection fails and the support is disabled when you really do want it. To force including support for ember-data you can use the `includeEmberDataSupport` option:
+
+```js
+// config/environment.js
+module.exports = function() {
+  var ENV = {
+    modulePrefix: 'my-app',
+    'ember-local-storage': {
+      includeEmberDataSupport: true
+    }
+  }
+};
+```
+
+NOTE: A common place you might run into this is on https://ember-twiddle.com for that case you can turn this option on by editing the `twiddle.json` to include the following:
+
+```json
+  "ENV": {
+    "ember-cli-local-storage": {
+      "includeEmberDataSupport": true
+    }
+  },
+```
+
 ### Object & Array
 
 #### Object

--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ module.exports = {
     if (projectConfig) {
       options = projectConfig['ember-local-storage'] || {};
 
+      if (options.includeEmberDataSupport === true) {
+        this.hasEmberData = true;
+      }
+
       if (options.fileExport && this.hasEmberData) {
         this.needsFileExport = true;
       }


### PR DESCRIPTION
This will allow someone to override the default stripping of ember-data support. This will allow ember-data support for environments that are not normal applications like ember-twiddle. Previously these environments were unable to have ember-data support.

Fixes #302