### PR TITLE
Remove an outdated hack

### DIFF
--- a/addon/adapters/base.js
+++ b/addon/adapters/base.js
@@ -103,15 +103,7 @@ export default JSONAPIAdapter.extend(ImportExportMixin, {
 
     return records
       .then(function(result) {
-        result = result.data[0];
-        // hack to fix https://github.com/emberjs/data/issues/3790
-        // and https://github.com/emberjs/data/pull/3866
-        try {
-          store.push({data: null});
-          return {data: result || null};
-        } catch(e) {
-          return {data: result || []};
-        }
+        return {data: result.data[0] || null};
       });
   },
 


### PR DESCRIPTION
The mentioned issue has been fixed in ember-data 2.2.1 on Nov 25, 2015 (https://github.com/emberjs/data/pull/3866#issuecomment-159745024).

The oldest version ember-local-storage currently supports is 2.12.
