### PR TITLE
feat: Allow `includeEmberDataSupport` to take precedence over VersionChecker results

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ module.exports = {
     if (projectConfig) {
       options = projectConfig['ember-local-storage'] || {};
 
-      if (options.includeEmberDataSupport === true) {
-        this.hasEmberData = true;
+      if ('includeEmberDataSupport' in options) {
+        this.hasEmberData = options.includeEmberDataSupport;
       }
 
       if (options.fileExport && this.hasEmberData) {


### PR DESCRIPTION
Right now, if your application has ember-data installed then there is no way of opting out of the initializer from executing.

This change makes it so that if you specify `includeEmberDataSupport` it will determine whether or not the initializer is bundled.