### PR TITLE
[BUGFIX] Replace `window.removeEventHandler` with `window.removeEventListener`.

### DIFF
--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -106,7 +106,7 @@ export default Mixin.create({
 
   willDestroy() {
     if (this._storageEventHandler) {
-      window.removeEventHandler('storage', this._storageEventHandler, false);
+      window.removeEventListener('storage', this._storageEventHandler, false);
     }
 
     this._super(...arguments);


### PR DESCRIPTION
AFAIK `window.removeEventHandler` does not exist in any browser, it must be a typo.