### PR TITLE
Guard against missing window.navigator to allow fastboot

### DIFF
--- a/vendor/save-as.js
+++ b/vendor/save-as.js
@@ -8,7 +8,7 @@
 
 window.saveAs || (
   window.saveAs = (
-    window.navigator.msSaveBlob ? function(b,n) {
+    (window.navigator && window.navigator.msSaveBlob) ? function(b,n) {
       return window.navigator.msSaveBlob(b,n);
     } : false
   ) ||


### PR DESCRIPTION
@vlascik can you check if the changes in this branch `fix-fastboot` solve the problem?