### PR TITLE
Remove assign usage

### DIFF
--- a/addon/helpers/import-export.js
+++ b/addon/helpers/import-export.js
@@ -1,15 +1,12 @@
 import { all, Promise } from 'rsvp';
-import { assign, merge } from '@ember/polyfills';
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import { singularize } from 'ember-inflector';
 import { A } from '@ember/array';
 
-const assignIt = assign || merge;
-
 export function importData(store, content, options) {
   // merge defaults
-  options = assignIt({
+  options = Object.assign({
     json: true,
     truncate: true
   }, options || {});
@@ -60,7 +57,7 @@ export function importData(store, content, options) {
 
 export function exportData(store, types, options) {
   // merge defaults
-  options = assignIt({
+  options = Object.assign({
     json: true,
     download: false,
     filename: 'ember-data.json'

--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -1,11 +1,8 @@
-import { assign, merge } from '@ember/polyfills';
 import Mixin from '@ember/object/mixin';
 import { set, get } from '@ember/object';
 import { isArray, A } from '@ember/array';
 import { getStorage } from '../helpers/storage';
 import { copy } from 'ember-copy'
-
-const assignIt = assign || merge;
 
 export default Mixin.create({
   _storageKey: null,
@@ -35,7 +32,7 @@ export default Mixin.create({
     // Retrieve the serialized version from storage.
     serialized = storage[storageKey];
     if (serialized) {
-      assignIt(content, JSON.parse(serialized));
+      Object.assign(content, JSON.parse(serialized));
     }
 
     // Do not change to set(this, 'content', content)


### PR DESCRIPTION
- Fixes Ember 4 deprecation warning https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign