### PR TITLE
Fix deprecation: `ember-data:deprecate-snapshot-model-class-access`.

### DIFF
--- a/addon/serializers/serializer.js
+++ b/addon/serializers/serializer.js
@@ -39,7 +39,8 @@ export default JSONAPISerializer.extend({
       if (belongsTo === null || belongsToIsNotNew) {
         json.relationships = json.relationships || {};
 
-        let payloadKey = this._getMappedKey(key, snapshot.type);
+        let modelType = this.store.modelFor(snapshot.modelName);
+        let payloadKey = this._getMappedKey(key, modelType);
         if (payloadKey === key) {
           payloadKey = this.keyForRelationship(key, 'belongsTo', 'serialize');
         }
@@ -67,7 +68,8 @@ export default JSONAPISerializer.extend({
       if (hasMany !== undefined) {
         json.relationships = json.relationships || {};
 
-        let payloadKey = this._getMappedKey(key, snapshot.type);
+        let modelType = this.store.modelFor(snapshot.modelName);
+        let payloadKey = this._getMappedKey(key, modelType);
         if (payloadKey === key && this.keyForRelationship) {
           payloadKey = this.keyForRelationship(key, 'hasMany', 'serialize');
         }


### PR DESCRIPTION
ember-data 4.5.0 [introduced](https://github.com/emberjs/data/pull/8055
) a new deprecation:
> DEPRECATE_SNAPSHOT_MODEL_CLASS_ACCESS removes support for snapshot.type in favor of calling store.modelFor(<modelName>) or using the schema service

This PR fixes it.