### PR TITLE
Bump node version to 14 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -71,7 +71,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
To have the tests running until the following fix landed in Beta and Release
- https://github.com/emberjs/data/pull/8108 (Beta)
- https://github.com/emberjs/data/pull/8145 (Release)

we use node 14 for CI