### PR TITLE
Ensure storage objects are destroyed on application teardown in tests

### DIFF
--- a/addon/adapters/local.js
+++ b/addon/adapters/local.js
@@ -2,6 +2,7 @@ import { get } from '@ember/object';
 import BaseAdapter from './base';
 import { getStorage, _buildKey } from '../helpers/storage';
 import StorageArray from '../local/array';
+import { getOwner } from '@ember/application';
 
 export default BaseAdapter.extend({
   _storage: getStorage('local'),
@@ -11,8 +12,10 @@ export default BaseAdapter.extend({
 
     if (!indices[type]) {
       let storageKey = _buildKey(this, 'index-' + type);
-
-      indices[type] = StorageArray.extend({ _storageKey: storageKey }).create();
+      let owner = getOwner(this);
+      indices[type] = StorageArray.extend({ _storageKey: storageKey }).create(
+        owner.ownerInjection()
+      );
     }
 
     return indices[type];

--- a/addon/adapters/session.js
+++ b/addon/adapters/session.js
@@ -2,6 +2,7 @@ import { get } from '@ember/object';
 import BaseAdapter from './base';
 import { getStorage, _buildKey } from '../helpers/storage';
 import StorageArray from '../session/array';
+import { getOwner } from '@ember/application';
 
 export default BaseAdapter.extend({
   _storage: getStorage('session'),
@@ -11,8 +12,10 @@ export default BaseAdapter.extend({
 
     if (!indices[type]) {
       let storageKey = _buildKey(this, 'index-' + type);
-
-      indices[type] = StorageArray.extend({ _storageKey: storageKey }).create();
+      let owner = getOwner(this);
+      indices[type] = StorageArray.extend({ _storageKey: storageKey }).create(
+        owner.ownerInjection()
+      );
     }
 
     return indices[type];

--- a/addon/mixins/storage.js
+++ b/addon/mixins/storage.js
@@ -3,6 +3,8 @@ import { set, get } from '@ember/object';
 import { isArray, A } from '@ember/array';
 import { getStorage } from '../helpers/storage';
 import { copy } from 'ember-copy';
+import { getOwner } from '@ember/application';
+import { associateDestroyableChild } from '@ember/destroyable';
 
 export default Mixin.create({
   _storageKey: null,
@@ -41,7 +43,10 @@ export default Mixin.create({
     // Keep in sync with other windows
     this._addStorageListener();
 
-    return this._super(...arguments);
+    this._super(...arguments);
+
+    let owner = getOwner(this);
+    associateDestroyableChild(owner, this);
   },
 
   _getInitialContentCopy() {
@@ -86,6 +91,7 @@ export default Mixin.create({
   },
 
   _save() {
+    if (this.isDestroying || this.isDestroyed) return;
     const storage = this._storage();
     const content = get(this, 'content');
     const storageKey = get(this, '_storageKey');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-version-checker": "^5.1.2",
-    "ember-copy": "^2.0.1"
+    "ember-copy": "^2.0.1",
+    "ember-destroyable-polyfill": "^2.0.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
Resolves #376
This is to ensure that storage objects are destroyed when the app is torn down in tests, currently objects created by `storageFor` are not destroyed after the test is torn down, i _think_ this is because the class is returned by a computed property so is not destroyed by the parent that calls `storageFor`

Storage instances of adapters are destroyed but i have added owner injection to ensure that `associateDestroyableChild` does not error with a missing owner.

to ensure backward compatibility i have also added the destroyable polyfill
 